### PR TITLE
Add support for deploying to Google App Engine

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,17 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Node.js dependencies:
+node_modules/

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,2 @@
+service: bank
+runtime: nodejs12

--- a/index.js
+++ b/index.js
@@ -221,24 +221,26 @@ const resolvers = {
   },
 };
 
-const server = new ApolloServer({ typeDefs, resolvers });
+const server = new ApolloServer({ typeDefs, resolvers, introspection: true });
 
 const app = express();
-server.applyMiddleware({ app });
+server.applyMiddleware({ app, path: "/bank/graphql" });
 
-app.get("/version", (req, res) => {
+app.get("/bank/version", (req, res) => {
   res.json({
     version: "0.0.0",
   });
 });
 
-app.get("/openapi", (req, res) => {
+app.get("/bank/openapi", (req, res) => {
   res.json(openapi);
 });
 
-app.listen({ port: 4000 }, () =>
+const PORT = 8080;
+
+app.listen({ port: PORT }, () =>
   console.log(
-    `Server ready at http://localhost:4000 with graphql at http://localhost:4000${server.graphqlPath}
-and openapi spec visible at http://localhost:4000/openapi. Have fun!`
+    `Server ready at http://localhost:${PORT} with graphql at http://localhost:${PORT}${server.graphqlPath}
+and openapi spec visible at http://localhost:${PORT}/bank/openapi. Have fun!`
   )
 );

--- a/openapi.js
+++ b/openapi.js
@@ -3,7 +3,7 @@ exports.openapi = {
   servers: [
     {
       description: "Localhost rules!",
-      url: "http://localhost:4000",
+      url: process.env.GAE_ENV ? "http://meeshkan.io/bank" : "http://localhost:8080/bank",
     },
   ],
   info: {


### PR DESCRIPTION
See current deployment under https://meeshkan.io/bank, with a GraphQL endpoint at https://meeshkan.io/bank/graphql

This may be used as a simple playground for testing our GraphQL runner against a public endpoint.